### PR TITLE
Replace Add-Content with Set-Content when writing pm2service.xml

### DIFF
--- a/pm2-service-install.ps1
+++ b/pm2-service-install.ps1
@@ -161,7 +161,8 @@ $serviceConfig=@"
     <arguments>-File "%BASE%\pm2service.ps1"</arguments>
 </service>
 "@
-Add-Content -Path "$pm2Path\service\pm2service.xml" -Value $serviceConfig
+# Use Set-Content to overwrite the file
+Set-Content -Path "$pm2Path\service\pm2service.xml" -Value $serviceConfig
 
 Set-Location "$pm2Path\service"
 & ./pm2service.exe Install


### PR DESCRIPTION
Fix PM2 service XML configuration file creation

- Replace Add-Content with Set-Content when writing pm2service.xml
- Ensures only one root <service> element in the configuration
- Resolves "Multiple root elements" error during service installation